### PR TITLE
First draft of TreeDamageEvent implementation

### DIFF
--- a/src/main/java/com/craftaro/ultimatetimber/events/TreeDamageEvent.java
+++ b/src/main/java/com/craftaro/ultimatetimber/events/TreeDamageEvent.java
@@ -1,0 +1,67 @@
+package com.craftaro.ultimatetimber.events;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.FallingBlock;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+
+public class TreeDamageEvent extends PlayerEvent implements Cancellable {
+
+    private boolean cancelled = false;
+    private FallingBlock blockAttacker = null;
+    private Player playerAttacker = null;
+    private static final HandlerList handlers = new HandlerList();
+
+    /**
+     * Represents a TreeDamage event.
+     */
+    public TreeDamageEvent(FallingBlock attacker, Player victim) {
+        super(victim);
+        this.blockAttacker = attacker;
+    }
+
+    // Hoping this one is used whenever possible
+    /**
+     * Represents a TreeDamage event.
+     */
+    public TreeDamageEvent(Player attacker, Player victim) {
+        super(victim);
+        this.playerAttacker = attacker;
+    }
+
+    /**
+     * @return the attacker as either FallingBlock or Player
+     */
+    public Entity getAttacker() {
+        if (this.playerAttacker != null)
+            return this.playerAttacker;
+        if (this.blockAttacker != null)
+            return this.blockAttacker;
+
+        return null;
+    }
+
+    /**
+     * Get Player damaged by this event. This method is only here for clarification
+     */
+    public Player getVictim() {
+        return this.getPlayer();
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    public static HandlerList getHandlerList() {return handlers;}
+
+    @Override
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelState) {this.cancelled = cancelState;}
+}

--- a/src/main/java/com/craftaro/ultimatetimber/manager/TreeAnimationManager.java
+++ b/src/main/java/com/craftaro/ultimatetimber/manager/TreeAnimationManager.java
@@ -9,6 +9,7 @@ import com.craftaro.ultimatetimber.animation.TreeAnimationDisintegrate;
 import com.craftaro.ultimatetimber.animation.TreeAnimationFancy;
 import com.craftaro.ultimatetimber.animation.TreeAnimationNone;
 import com.craftaro.ultimatetimber.animation.TreeAnimationType;
+import com.craftaro.ultimatetimber.events.TreeDamageEvent;
 import com.craftaro.ultimatetimber.tree.DetectedTree;
 import com.craftaro.ultimatetimber.tree.ITreeBlock;
 import com.craftaro.ultimatetimber.tree.TreeDefinition;
@@ -199,7 +200,14 @@ public class TreeAnimationManager extends Manager implements Listener, Runnable 
                 if (!(entity instanceof LivingEntity)) {
                     continue;
                 }
-                ((LivingEntity) entity).damage(damage, fallingBlock);
+                if (entity instanceof Player) {
+                    Player p = ((Player) entity).getPlayer();
+                    TreeDamageEvent treeDamageEvent = new TreeDamageEvent(fallingBlock, p);
+                    Bukkit.getServer().getPluginManager().callEvent(treeDamageEvent);
+                    if (!treeDamageEvent.isCancelled())
+                        ((LivingEntity) entity).damage(damage, fallingBlock);
+                } else
+                    ((LivingEntity) entity).damage(damage, fallingBlock);
             }
         }
 


### PR DESCRIPTION
Currently, trees can damage players which allows people in PVP protected areas to plant a tree and timber it. Adding this Event can make the detection of this more reliable and easier to implement. 