### PR TITLE
Update config.yml - cover dark oak / pale oak edge case

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -317,7 +317,7 @@ trees:
       - VINE
     sapling: DARK_OAK_SAPLING
     plantable-soil: [ ]
-    max-log-distance-from-trunk: 3
+    max-log-distance-from-trunk: 4
     max-leaf-distance-from-log: 5
     search-for-leaves-diagonally: false
     drop-original-log: true
@@ -511,7 +511,7 @@ trees:
       - PALE_HANGING_MOSS
     sapling: PALE_OAK_SAPLING
     plantable-soil: [ ]
-    max-log-distance-from-trunk: 3
+    max-log-distance-from-trunk: 4
     max-leaf-distance-from-log: 5
     search-for-leaves-diagonally: false
     drop-original-log: true


### PR DESCRIPTION
update dark oak / pale oak trunk config to include edge case to prevent floating logs

<img width="1891" height="1077" alt="image" src="https://github.com/user-attachments/assets/b215f84f-cea4-4c51-b8a2-70dd26bffd38" />

here is the dark oak / pale oak tree generation chart that shows the log 4 blocks away (presumably should fix this)